### PR TITLE
IDENTITY-6113: SSO Agent fixes identified during QSG SSO SAML demo app implementations

### DIFF
--- a/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/saml/SAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/saml/SAML2SSOManager.java
@@ -468,14 +468,15 @@ public class SAML2SSOManager {
             throw new SSOAgentException("SAML2 Response does not contain the name of the subject");
         }
 
-
+        // This should be the only time where a new session can be created.
+        // Thus in latter places request.getSession(false) should be used.
         sessionBean.getSAML2SSO().setSubjectId(subject); // set the subject
         request.getSession().setAttribute(SSOAgentConstants.SESSION_BEAN_NAME, sessionBean);
 
         // Marshalling SAML2 assertion after signature validation due to a weird issue in OpenSAML
         sessionBean.getSAML2SSO().setAssertionString(marshall(assertion));
 
-        ((LoggedInSessionBean) request.getSession().getAttribute(
+        ((LoggedInSessionBean) request.getSession(false).getAttribute(
                 SSOAgentConstants.SESSION_BEAN_NAME)).getSAML2SSO().
                 setSubjectAttributes(getAssertionStatements(assertion));
 
@@ -485,12 +486,12 @@ public class SAML2SSOManager {
             if (sessionId == null) {
                 throw new SSOAgentException("Single Logout is enabled but IdP Session ID not found in SAML2 Assertion");
             }
-            ((LoggedInSessionBean) request.getSession().getAttribute(
+            ((LoggedInSessionBean) request.getSession(false).getAttribute(
                     SSOAgentConstants.SESSION_BEAN_NAME)).getSAML2SSO().setSessionIndex(sessionId);
             SSOAgentSessionManager.addAuthenticatedSession(request.getSession(false));
         }
 
-        request.getSession().setAttribute(SSOAgentConstants.SESSION_BEAN_NAME, sessionBean);
+        request.getSession(false).setAttribute(SSOAgentConstants.SESSION_BEAN_NAME, sessionBean);
 
     }
 

--- a/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/saml/SSOAgentHttpSessionListener.java
+++ b/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/saml/SSOAgentHttpSessionListener.java
@@ -34,6 +34,9 @@ public class SSOAgentHttpSessionListener implements HttpSessionListener {
     @Override
     public void sessionCreated(HttpSessionEvent httpSessionEvent) {
         if (httpSessionEvent.getSession().getAttribute(SSOAgentConstants.SESSION_BEAN_NAME) == null) {
+            // This log is not accurate, since we depend on request.getSession() to create new session
+            // if there is no existing session. After that only we set the Session-Bean.
+            // Thus in this listener the session always does not contain a Session-Bean Attribute.
             LOGGER.log(Level.WARNING, "HTTP Session created without LoggedInSessionBean");
         }
     }

--- a/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/saml/SSOAgentSessionManager.java
+++ b/components/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/saml/SSOAgentSessionManager.java
@@ -49,7 +49,9 @@ public class SSOAgentSessionManager {
             String sessionIndex = sessionBean.getSAML2SSO().getSessionIndex();
             if (sessionIndex != null) {
                 Set<HttpSession> sessions = ssoSessionsMap.get(sessionIndex);
-                sessions.remove(session);
+                if (sessions != null) {
+                    sessions.remove(session);
+                }
             }
         }
     }


### PR DESCRIPTION
During a Quick Start Guide SSO Demo App development found theses minor issues and fixed them.
Some comments were introduced to clarify things with the intention of avoiding possible misleads.